### PR TITLE
新增 awesome-ai-api 到 LLM评测 章节（AI API 中转站每日评测榜）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,6 +1124,12 @@
     ![](https://img.shields.io/github/stars/jeinlee1991/chinese-llm-benchmark.svg)
   * 简介：中文大模型能力评测榜单：覆盖百度文心一言、chatgpt、阿里通义千问、讯飞星火、belle / chatglm6b 等开源大模型，多维度能力评测。不仅提供能力评分排行榜，也提供所有模型的原始输出结果！
 
+* awesome-ai-api：中文 AI API 中转站每日评测榜
+
+  * 地址：https://github.com/MackDing/awesome-ai-api
+    ![](https://img.shields.io/github/stars/MackDing/awesome-ai-api.svg)
+  * 简介：每日自动刷新的 AI API 中转站（OpenAI 兼容 Relay）公开排行榜，覆盖国内外 200+ 中转站。通过每天探测 `/v1/models` 端点、识别底层 OSS 引擎（one-api / new-api / dify / litellm / portkey 等）、累计 30 天可用率、测量延迟，综合打分并输出榜单。数据 CC0 开源，代码 MIT 协议，在线榜单：https://mackding.github.io/awesome-ai-api/ 。
+
 * Safety-Prompts：
   
   * 地址：https://github.com/thu-coai/Safety-Prompts


### PR DESCRIPTION
您好 @HqWu-HITCS 👋 —— 来自深圳的开发者！🇨🇳

本 PR 在 **§6 LLM评测** 章节新增一个中文 AI 生态相关的条目：

## 📌 项目简介

[**awesome-ai-api**](https://github.com/MackDing/awesome-ai-api) —— 一个**每日自动刷新**的 AI API 中转站（OpenAI 兼容 Relay）公开排行榜，覆盖**国内外 200+ 中转站**。

虽然项目本身不直接评测"大模型"，但它评测的是**"承载中文开发者调用大模型的基础设施"**——即数以百计的国内中转站（new-api / one-api / dify / fastgpt 等开源引擎构建），这恰好是中文 LLM 生态里一个**尚无公开榜单**的空白区域。

## 🔬 评测方法

- 每 24 小时探测每个中转站的 `/v1/models` 端点（OpenAI 兼容）
- 识别底层 OSS 引擎指纹（one-api / new-api / dify / litellm / portkey / FastGPT / OpenRouter 等）
- 累计 30 天可用率、测量 HTTP 延迟、抽查模型清单
- 综合打分并按分排序，生成榜单

## 📊 当前规模（2026-04-23 快照）

- **总记录**：201 个中转站
- **已验证 /v1/models**：101 个
- **引擎分类**：9 种
- **在线榜单**：https://mackding.github.io/awesome-ai-api/
- **中文版**：https://mackding.github.io/awesome-ai-api/zh/

## 📄 开放协议

- **代码**：MIT
- **数据**：CC0（任何人可自由使用）
- **原始 JSON**：https://mackding.github.io/awesome-ai-api/gateways.json

## ✅ PR 质量自检

- 只改动 README.md，**+6 行纯新增**
- 格式（bullet / 地址 / stars 徽章 / 简介）与相邻条目完全一致
- 插入位置：`chinese-llm-benchmark` 之后、`Safety-Prompts` 之前（同属榜单类条目）
- 与 upstream/main 无冲突，可 fast-forward merge
- 所有链接返回 HTTP 200

如果您觉得该条目不适合 `LLM评测` 章节，放到 `§5 LLM推理部署框架` 也可以，完全听从您的安排，非常感谢您维护这个列表！🙏
