### PR TITLE
添加 AI Models Catalog — 95个AI提供商4587+模型结构化目录

### DIFF
--- a/README.md
+++ b/README.md
@@ -1222,6 +1222,10 @@
   
   ### 8. <a name='相关仓库'></a>相关仓库
 
+* AI Models Catalog：
+  * 地址：https://github.com/i-need-token/ai-models
+  * 简介：95个AI提供商的4587+模型结构化目录，包含定价、上下文窗口和能力信息。一手数据，TypeScript类型+Zod校验。提供交互式目录（搜索、筛选、对比、导出）和价格计算器。[交互式目录](https://i-need-token.github.io/ai-models/)
+
 * FindTheChatGPTer：
   
   * 地址：https://github.com/chenking2020/FindTheChatGPTer


### PR DESCRIPTION
## 添加

**AI Models Catalog** — 95个AI提供商的4587+模型结构化目录，包含定价、上下文窗口和能力信息。所有数据来自一手API。

### 为什么适合
- **全面** — 95个提供商，4587+模型，441个模型系列
- **一手数据** — 定价、上下文窗口和能力均来自官方API验证
- **实用工具** — 交互式目录（搜索、筛选、对比、导出CSV/JSON）、价格计算器、模型选择器
- **开源** — MIT许可，npm包，GitHub Action，YAML + JSON + CSV格式
- **中文友好** — 包含阿里通义千问、百度文心、字节豆包、MiniMax、月之暗面、阶跃星辰等中国AI提供商

### 链接
- 仓库：https://github.com/i-need-token/ai-models
- 交互式目录：https://i-need-token.github.io/ai-models/

添加到**相关仓库**部分。