### PR TITLE
docs: add langchain-langgraph-langsmith-tutorial to LLM应用教程

### DIFF
--- a/README.md
+++ b/README.md
@@ -1196,6 +1196,12 @@
     ![](https://img.shields.io/github/stars/phodal/aigc.svg)
   * 简介：该项目开源了一本关于 LLM 在真实世界应用的开源电子书，介绍了大语言模型的基础知识和应用，以及如何构建自己的模型。其中包括Prompt的编写、开发和管理，探索最好的大语言模型能带来什么，以及LLM应用开发的模式和架构设计。
 
+* langchain-langgraph-langsmith-tutorial（LangChain Tutorial Zero）：
+
+  * 地址：https://github.com/estelledc/langchain-langgraph-langsmith-tutorial
+    ![](https://img.shields.io/github/stars/estelledc/langchain-langgraph-langsmith-tutorial.svg)
+  * 简介：给编程零基础选手的 LangChain 1.3.x 中文教程，4 周 14 篇 learning-by-doing。包含 AI 辅助学习元教程（7 条 prompt 心法 + 任务卡结构）、LangChain / LangGraph / LangSmith 三件套覆盖、6 处 1.3.x 破坏性变更修法实测，所有 final/.py 可直接跑通。
+
 #### LLM实战教程
 
 * LLMs九层妖塔：


### PR DESCRIPTION
## 新增条目

- 项目：[langchain-langgraph-langsmith-tutorial](https://github.com/estelledc/langchain-langgraph-langsmith-tutorial)
- 章节：7. LLM教程 → LLM应用教程

## 简介

面向编程零基础学习者的 LangChain 1.3.x 中文教程，4 周共 14 篇 learning-by-doing 实战章节。覆盖 LangChain / LangGraph / LangSmith 三件套从环境搭建到 Agent 编排的完整链路。

## 与已收录条目的差异

本节已有的「LangChain 中文网」是文档站，「OpenAI Cookbook」偏 OpenAI API 而非 LangChain，「构筑大语言模型应用」偏架构层。本仓库的差异化定位：

- **零基础友好**：每个新概念先用日常生活类比（API key = 出入证、向量数据库 = 索引卡片柜），再进入技术定义，不假设懂任何术语
- **LangChain 1.3.x 实测**：当前许多中文 LangChain 教程仍停留在 0.x API（已 deprecated），本教程基于 1.3.x 全新 API 实测，记录 6 处破坏性变更修法（pydantic_v1 迁移 / langchain_classic 拆包 / LangChainStringEvaluator 移除等）
- **AI 辅助学习元教程**：附 7 条 prompt 心法 + 任务卡结构，记录用 Claude Code / Cursor 辅助学新框架的提问模板与排查路径，对所有 AI 时代的自学者有迁移价值

## 仓库现状

- 仓库 14 ⭐（小而新，但定位差异化清晰）
- pre-commit lint 强制校验链接、来源字段
- 维护承诺：跟进 LangChain 2.x 升级周期
