### PR TITLE
添加 AMD Strix Halo 本地 LLM 配置与基准指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -1198,6 +1198,12 @@
 
 #### LLM实战教程
 
+* AMD Strix Halo 本地 LLM 配置与基准指南：
+
+  * 地址：https://github.com/hogeheer499-commits/strix-halo-guide
+    ![](https://img.shields.io/github/stars/hogeheer499-commits/strix-halo-guide.svg)
+  * 简介：该项目提供 AMD Ryzen AI MAX+ 395 / Radeon 8060S 统一内存系统上的可复现本地 LLM 配置与基准，涵盖 Ubuntu、Ollama、llama.cpp、Vulkan/RADV、ROCm、模型与量化选择、原始日志以及失败路线。
+
 * LLMs九层妖塔：
   
   * 地址：https://github.com/km1994/LLMsNineStoryDemonTower


### PR DESCRIPTION
## 说明

在「LLM实战教程」中添加一个 AMD Strix Halo 本地 LLM 配置与基准资源。

该指南面向 Ryzen AI MAX+ 395 / Radeon 8060S 统一内存系统，提供可复现的 Ubuntu、Ollama、llama.cpp、Vulkan/RADV 和 ROCm 路线，并包含模型与量化选择、原始基准日志和失败路线。它可以补充本仓库中的 Qwen、DeepSeek 等中文模型和推理部署资源。

## 检查

- 放置在现有「LLM实战教程」章节
- 遵循现有的地址、stars badge 和简介格式
- `git diff --check` 通过
- 已验证链接返回 HTTP 200
